### PR TITLE
Fix incorrect reading of xsettings count

### DIFF
--- a/xdpi.c
+++ b/xdpi.c
@@ -156,7 +156,7 @@ int pad_to_int32(int n) {
 Bool xsettings_find_xft_dpi(unsigned char *buffer, unsigned int scrnum, Bool printed_xset_hdr)
 {
 	/* TODO check byte order */
-	uint32_t num_settings = ((uint32_t*)buffer)[4];
+	uint32_t num_settings = ((uint32_t*)buffer)[2];
 
 	/* Skip rest of header */
 	buffer += 12;


### PR DESCRIPTION
According to the XSETTINGS spec, settings count starts at offset 8. When casting to an uint32_t array, correct index is 2.
Tested with xsettingsd. Without this patch if xsettings doesn't contain `Xft/DPI` property, xdpi fails with segmentation fault due to heap buffer overflow read.